### PR TITLE
Fix edgePadding prop usage in ClusteredMapView

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -169,7 +169,7 @@ const ClusteredMapView = forwardRef(
       }));
 
       mapRef.current.fitToCoordinates(coordinates, {
-        edgePadding: restProps.edgePadding,
+        edgePadding: edgePadding,
       });
 
       onClusterPress && onClusterPress(cluster, children);


### PR DESCRIPTION
The edgePadding prop is never passed to fitToCoordinates because the code uses restProps.edgePadding instead of the local edgePadding variable. As a result, custom values are ignored and the default is always used.